### PR TITLE
env_template の source 参照を GitHub に変更

### DIFF
--- a/bin/generate-variables-example.sh
+++ b/bin/generate-variables-example.sh
@@ -52,10 +52,11 @@ function print_module_example {
   local variables_file="$1"
   local module_dir="$(dirname "${variables_file}")"
   local module_name="$(basename "${module_dir}")"
+  local module_base="../"
 
     cat - << EOF | terraform fmt - | comment_out_module_vars
     module "${module_name//-/_}" {
-      source = "../${module_dir}"
+      source = "${module_base}${module_dir}"
       $(construct_example "${variables_file}")
     }
 EOF

--- a/bin/generate-variables-example.sh
+++ b/bin/generate-variables-example.sh
@@ -53,10 +53,11 @@ function print_module_example {
   local module_dir="$(dirname "${variables_file}")"
   local module_name="$(basename "${module_dir}")"
   local module_base="../"
+  local revision_ref=""
 
     cat - << EOF | terraform fmt - | comment_out_module_vars
     module "${module_name//-/_}" {
-      source = "${module_base}${module_dir}"
+      source = "${module_base}${module_dir}${revision_ref}"
       $(construct_example "${variables_file}")
     }
 EOF

--- a/bin/generate-variables-example.sh
+++ b/bin/generate-variables-example.sh
@@ -52,8 +52,8 @@ function print_module_example {
   local variables_file="$1"
   local module_dir="$(dirname "${variables_file}")"
   local module_name="$(basename "${module_dir}")"
-  local module_base="../"
-  local revision_ref=""
+  local module_base="github.com/lerna-stack/lerna-terraform//"
+  local revision_ref="?ref=main" # TODO: use version tag
 
     cat - << EOF | terraform fmt - | comment_out_module_vars
     module "${module_name//-/_}" {

--- a/env_template/facility-core.tf
+++ b/env_template/facility-core.tf
@@ -1,5 +1,5 @@
 module "core" {
-  source = "../modules/service/centos/core"
+  source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/core?ref=main"
 
   # 有効にするテナント
   //active_tenants = ["default"]

--- a/env_template/facility-dev.tf
+++ b/env_template/facility-dev.tf
@@ -1,5 +1,5 @@
 module "dev" {
-  source = "../modules/service/centos/dev"
+  source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/dev?ref=main"
 
   # [必須] HAProxy の SSH 用ホストリスト（HAProxy のインストール先）
   //haproxy_ssh_hosts = ["10.10.10.2"]

--- a/env_template/facility-ec2.tf
+++ b/env_template/facility-ec2.tf
@@ -1,5 +1,5 @@
 module "ec2" {
-  source = "../modules/platform/aws/ec2"
+  source = "github.com/lerna-stack/lerna-terraform//modules/platform/aws/ec2?ref=main"
 
   # [必須] AWS アクセスキー ID
   //aws_access_key = "AKIAxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
相対path参照だとコピーして使えないため。