### PR TITLE
サンプルプロジェクト(example/aws_ec2)をRHEL7に対応させる

### DIFF
--- a/examples/aws_ec2/facility-lerna-stack.tf
+++ b/examples/aws_ec2/facility-lerna-stack.tf
@@ -185,6 +185,7 @@ data "template_file" "app_arguments" {
   ### Basics
   -Dakka.cluster.min-nr-of-members=1
   -Dakka.remote.artery.canonical.hostname=${module.lerna_stack_platform_aws_ec2.app_instance_ips[count.index]}
+  -Dkamon.environment.host=${module.lerna_stack_platform_aws_ec2.app_instance_ips[count.index]}
   -Dkamon.system-metrics.host.sigar-native-folder=native/1
   -Dreactive.logs_dir=/apl/var/log/lerna-sample-payment-app
   -Djp.co.tis.lerna.payment.server-mode=PRODUCTION

--- a/examples/aws_ec2/facility-mock-server.tf
+++ b/examples/aws_ec2/facility-mock-server.tf
@@ -10,9 +10,8 @@ resource "null_resource" "setup_for_mock_server" {
   depends_on = [module.lerna_stack_service_redhat_core]
 
   triggers = {
-    docker_compose  = md5(data.template_file.docker_compose.rendered)
-    http_proxy_conf = md5(data.template_file.http_proxy_conf.rendered)
-    app_rpm         = filemd5(var.app_rpm_path)
+    app_rpm             = filemd5(var.app_rpm_path)
+    mock_server_service = md5(data.template_file.mock_server_service.rendered)
   }
 
   connection {
@@ -22,13 +21,8 @@ resource "null_resource" "setup_for_mock_server" {
   }
 
   provisioner "file" {
-    content     = data.template_file.docker_compose.rendered
-    destination = "/tmp/docker-compose.yml"
-  }
-
-  provisioner "file" {
-    content     = data.template_file.http_proxy_conf.rendered
-    destination = "/tmp/http-proxy.conf"
+    content     = data.template_file.mock_server_service.rendered
+    destination = "/tmp/mock-server.service"
   }
 
   provisioner "remote-exec" {
@@ -37,46 +31,18 @@ resource "null_resource" "setup_for_mock_server" {
     set -Cex
 
     sudo -E yum update -y
-    sudo -E yum install -y unzip wget
+    sudo -E yum install -y curl
 
-    # Install Docker Engine
-    # https://docs.docker.com/engine/install/centos/#install-using-the-repository
-    sudo -E yum install -y yum-utils
-    sudo -E yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    sudo -E yum install -y docker-ce docker-ce-cli containerd.io
+    # Install Node.js v12.x
+    # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions-1
+    curl -fsSL https://rpm.nodesource.com/setup_12.x | sudo bash -
+    sudo -E yum install -y nodejs
 
-    # Configure HTTP Proxy used by Docker
-    # https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
-    sudo mkdir -p /etc/systemd/system/docker.service.d
-    cat /tmp/http-proxy.conf | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf
+    sudo --askpass install --owner=root --group=lv4 --mode=0664 /tmp/mock-server.service /usr/lib/systemd/system/mock-server.service
+    sudo systemctl restart mock-server
+    sudo systemctl enable mock-server
 
-    # Install Docker Compose
-    # https://docs.docker.com/compose/install/#install-compose-on-linux-systems
-    curl -L https://github.com/docker/compose/releases/download/1.28.5/docker-compose-`uname -s`-`uname -m` | sudo tee /usr/local/bin/docker-compose > /dev/null
-    sudo chmod +x /usr/local/bin/docker-compose
-
-    sudo gpasswd -a ${var.ssh_user} docker
-    sudo systemctl daemon-reload
-    sudo systemctl restart docker
-    sudo systemctl enable docker
-
-    cat /tmp/docker-compose.yml | sudo tee ./docker-compose.yml
-
-    # Cleanup
-    rm -f /tmp/docker-compose.yml
-    rm -f /tmp/http-proxy.conf
-
-    EOC
-    ]
-  }
-
-  provisioner "remote-exec" {
-    inline = [<<-EOC
-
-    set -Cex
-
-    # Rebuild docker images & Restart docker containers
-    docker-compose up -d --build --force-recreate
+    rm /tmp/mock-server.service
 
     EOC
     ]
@@ -84,41 +50,24 @@ resource "null_resource" "setup_for_mock_server" {
 
 }
 
-data "template_file" "docker_compose" {
+data "template_file" "mock_server_service" {
   template = <<-EOF
 
-version: '3'
-
-services:
-  mock:
-    build:
-      context: ${local.mock-server-docker-filepath}
-      args:
-        http_proxy:
-        https_proxy:
-    restart: always
-    ports:
-      - 8083:3000
-
-  EOF
-}
-
-data "template_file" "http_proxy_conf" {
-  template = <<-EOF
-
-# See
-# https://docs.docker.jp/config/daemon/systemd.html#http-https
+[Unit]
+Description ="Mock Server for lerna-sample-payment-app"
+After = network.target
 
 [Service]
-${var.http_proxy_host != ""
-  ? "Environment=\"HTTP_PROXY=http://${var.http_proxy_host}:${var.http_proxy_port}\""
-  : ""
-  }
-${var.http_proxy_host != ""
-  ? "Environment=\"HTTPS_PROXY=http://${var.http_proxy_host}:${var.http_proxy_port}\""
-  : ""
-}
-Environment="NO_PROXY=localhost"
+Type = simple
+WorkingDirectory = ${local.mock-server-docker-filepath}
+ExecStartPre = /usr/bin/npm install
+ExecStart = /usr/bin/npm start -- --host '0.0.0.0' --port 8083
+ExecStop = /usr/bin/npm stop
+Restart = always
+RestartSec = 3
 
-  EOF
+[Install]
+WantedBy = multi-user.target
+
+EOF
 }

--- a/examples/aws_ec2/facility-mock-server.tf
+++ b/examples/aws_ec2/facility-mock-server.tf
@@ -62,7 +62,6 @@ Type = simple
 WorkingDirectory = ${local.mock-server-docker-filepath}
 ExecStartPre = /usr/bin/npm install
 ExecStart = /usr/bin/npm start -- --host '0.0.0.0' --port 8083
-ExecStop = /usr/bin/npm stop
 Restart = always
 RestartSec = 3
 

--- a/examples/aws_ec2/facility-mock-server.tf
+++ b/examples/aws_ec2/facility-mock-server.tf
@@ -39,6 +39,7 @@ resource "null_resource" "setup_for_mock_server" {
     sudo -E yum install -y nodejs
 
     sudo --askpass install --owner=root --group=lv4 --mode=0664 /tmp/mock-server.service /usr/lib/systemd/system/mock-server.service
+    sudo systemctl daemon-reload
     sudo systemctl restart mock-server
     sudo systemctl enable mock-server
 


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna-terraform/issues/10

## 変更点

- モックサーバを CentOS8 と RHEL7 の両方で動作できるようにします
  Docker Engine のインストールを CentOS8 と RHEL7 の両方に対応させることは難しそうでした。  
  モックサーバは Node.js で動作しており、Node.js を CentOS8 と RHEL7 の両方にインストールすることは簡単でした。  
  Docker Engine をインストールする必要はないため、モックサーバを動作させるために Node.js を直接使用します。
- Kamon 1.x のホスト名解決でエラーにならないように変更します
  RHEL7 では、Kamon 1.x のホスト名解決がエラーになりました。  
  ホスト名の自動解決を使わず、明示的に指定するようにします。

## 動作確認
CentOS8 と RHEL7 の AMI それぞれを使った場合について、
[動作確認](https://github.com/lerna-stack/lerna-terraform/blob/main/examples/aws_ec2/README.md#%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D) を実施して、期待通りのレスポンスが返ってくることを確認しました。