### PR TITLE
リリース v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ lerna-terraform に関する注目すべき変更はこのファイルで文書�
       詳細は [Cassandraバックアップ](docs/ops/Cassandraバックアップ.md) をご確認ください。
     - バックアップとリストアの手順を変更します  
       詳細は [Cassandraバックアップ](docs/ops/Cassandraバックアップ.md) と [Cassandraリストア](docs/ops/Cassandraリストア.md) をご確認ください。
+- ネットワーク分断時、HAProxyが切り離されない問題を修正します  
+  ネットワーク分断時にはマイノリティ側ではアプリが全滅する。その際、HAProxyは転送先がないが Keepalived からのヘルスチェックに OK を返すため Keepalived に切り離されず、エラーの原因となっていた。
 
 ## v1.0.0
 初回リリース

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ lerna-terraform に関する注目すべき変更はこのファイルで文書�
 このファイルの書き方については [変更履歴の書き方](docs/dev/変更履歴の書き方.md) を参照してください。
 
 ## Unreleased
-- Red Hat Enterprise Linux 7 (RHEL7) に対応する
-  - [RedHatEnterpriseLinux7利用ガイド](docs/dev/RedHatEnterpriseLinux7利用ガイド.md)
+
+## v1.1.0
+- モジュール名を変更します  
+  `service/centos/core` を `service/redhat/core` に変更します。
+  `service/centos/dev` を `service/redhat/dev` に変更します。  
+  v1.0.0を利用している場合は移行作業が必要になります。  
+  詳細は [マイグレーションガイド v1.1.0 from v1.0.0](MIGRATION.md#v110-from-v100) をご確認ください。
+- Red Hat Enterprise Linux 7 (RHEL7) に対応します  
+  利用方法は [RedHatEnterpriseLinux7利用ガイド](docs/dev/RedHatEnterpriseLinux7利用ガイド.md) をご確認ください。
 - アプリ停止のタイムアウト値を設定可能にします  
   `app_stop_timeout_sec` で設定できます。  
   アプリケーションのグレースフルシャットダウンよりも十分な時間にするため、  

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # マイグレーションガイド
 
-## (未リリース) To v2.0.0 From v1.0.0
+## v1.1.0 from v1.0.0
 
 ### モジュール名の変更
 
@@ -22,8 +22,8 @@ module "your-module-name" {
     // v1.0.0
     // source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/core?ref=v1.0.0"
 
-    // v2.0.0
-    source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/core?ref=v2.0.0"
+    // v1.1.0
+    source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/core?ref=v1.1.0"
 
     // ... truncated ...
 }
@@ -33,8 +33,8 @@ module "your-module-name" {
     // v1.0.0
     // source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/dev?ref=v1.0.0"
 
-    // v2.0.0
-    source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/dev?ref=v2.0.0"
+    // v1.1.0
+    source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/dev?ref=v1.1.0"
 
     // ... truncated ...
 }

--- a/bin/generate-variables-example.sh
+++ b/bin/generate-variables-example.sh
@@ -53,7 +53,7 @@ function print_module_example {
   local module_dir="$(dirname "${variables_file}")"
   local module_name="$(basename "${module_dir}")"
   local module_base="github.com/lerna-stack/lerna-terraform//"
-  local revision_ref="?ref=v1.0.0"
+  local revision_ref="?ref=v1.1.0"
 
     cat - << EOF | terraform fmt - | comment_out_module_vars
     module "${module_name//-/_}" {

--- a/env_template/facility-core.tf
+++ b/env_template/facility-core.tf
@@ -1,5 +1,5 @@
 module "core" {
-  source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/core?ref=v1.0.0"
+  source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/core?ref=v1.1.0"
 
   # 有効にするテナント
   //active_tenants = ["default"]
@@ -108,6 +108,9 @@ module "core" {
 
   # アプリのヒープダンプや JVM の致命的エラーログファイルをダンプする場所。デフォルトは sbt-native-packager デフォルトのログディレクトリ。https://sbt-native-packager.readthedocs.io/en/latest/archetypes/cheatsheet.html?highlight=defaultLinuxLogsLocation#settings
   //app_dump_dir = "/var/log"
+
+  # アプリ停止のタイムアウト値
+  //app_stop_timeout_sec = "5min"
 
   # プロジェクト特有のアプリケーションの起動引数。リストの index は app_cluster_hosts と対応し、設定が app_cluster_hosts と対応する各サーバーに配置されます
   //app_arguments = []

--- a/env_template/facility-dev.tf
+++ b/env_template/facility-dev.tf
@@ -1,5 +1,5 @@
 module "dev" {
-  source = "github.com/lerna-stack/lerna-terraform//modules/service/centos/dev?ref=v1.0.0"
+  source = "github.com/lerna-stack/lerna-terraform//modules/service/redhat/dev?ref=v1.1.0"
 
   # [必須] HAProxy の SSH 用ホストリスト（HAProxy のインストール先）
   //haproxy_ssh_hosts = ["10.10.10.2"]

--- a/env_template/facility-ec2.tf
+++ b/env_template/facility-ec2.tf
@@ -1,5 +1,5 @@
 module "ec2" {
-  source = "github.com/lerna-stack/lerna-terraform//modules/platform/aws/ec2?ref=v1.0.0"
+  source = "github.com/lerna-stack/lerna-terraform//modules/platform/aws/ec2?ref=v1.1.0"
 
   # [必須] AWS アクセスキー ID
   //aws_access_key = "AKIAxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
v1.1.0 をリリースします。

- マイグレーションガイドの改訂
  バージョン番号を変更します (1.1.0 <= 2.0.0)
- CHANGELOGの改訂
- モジュールテンプレート (env_emplate/***) の更新
  v1.1.0 を使用します
- フォーマットスクリプト (bin/bin/generate-variables-example.sh) の更新
  v1.1.0 を使用します

## TODO
- [x] Fix HAProxy not being detached https://github.com/lerna-stack/lerna-terraform/pull/9 がマージされること

## NOTE
- [x] このPRをマージした後にタグ v1.1.0 を作成します。
  - [Release Version 1.1.0 · lerna-stack/lerna-terraform](https://github.com/lerna-stack/lerna-terraform/releases/tag/v1.1.0)