### PR TITLE
refactor: cassandra service 定義から不要な記述を削除

### DIFF
--- a/modules/service/redhat/core/facility-cassandra.tf
+++ b/modules/service/redhat/core/facility-cassandra.tf
@@ -182,11 +182,10 @@ data "template_file" "cassandra_service" {
   After=network.target
 
   [Service]
-  PIDFile=/var/run/cassandra/cassandra.pid
   User=cassandra
   Group=cassandra
   Environment="JAVA_HOME=${var.cassandra_java_home}"
-  ExecStart=/usr/sbin/cassandra -f -p /var/run/cassandra/cassandra.pid
+  ExecStart=/usr/sbin/cassandra -f
   StandardOutput=journal
   StandardError=journal
   LimitNOFILE=1048576


### PR DESCRIPTION
cassandra を `-f` で foreground 起動する場合、pid ファイルによる管理は不要


## 参考
[The cassandra utility | Apache Cassandra 3.0](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/tools/toolsCUtility.html#toolsCUtility__general-options)

```
-f	Start the cassandra process in foreground. The default is to start as background process.
```
```
-p filename	Log the process ID in the named file. Useful for stopping Cassandra by killing its PID.
```

