### PR TITLE
Cassandraバックアップ.md にあるリンク切れを修正

### DIFF
--- a/docs/ops/Cassandraバックアップ.md
+++ b/docs/ops/Cassandraバックアップ.md
@@ -88,4 +88,4 @@ total 16
 [redhat/core]: /modules/service/redhat/core
 [examples/aws_ec2]: /examples/aws_ec2
 [facility-cassandra-backup.tf]: /examples/aws_ec2/facility-cassandra-backup.tf
-[Cassandraバックアップ方式]: /docs/dev/Cassandraバックアップ方式
+[Cassandraバックアップ方式]: /docs/dev/Cassandraバックアップ方式.md


### PR DESCRIPTION
`Cassandraバックアップ方式` のリンクを押すと 404 ページに飛ばされます。

> バックアップのノード数を決める計算方法は Cassandraバックアップ方式 を確認してください。
>
> **[lerna-terraform/Cassandraバックアップ.md at v1.1.0 · lerna-stack/lerna-terraform](https://github.com/lerna-stack/lerna-terraform/blob/v1.1.0/docs/ops/Cassandra%E3%83%90%E3%83%83%E3%82%AF%E3%82%A2%E3%83%83%E3%83%97.md#:~:text=%E3%83%90%E3%83%83%E3%82%AF%E3%82%A2%E3%83%83%E3%83%97%E3%81%AE,%E3%80%82)**

正しいパスは次の通りです：
[`/docs/dev/Cassandraバックアップ方式.md`](https://github.com/lerna-stack/lerna-terraform/blob/main/docs/dev/Cassandra%E3%83%90%E3%83%83%E3%82%AF%E3%82%A2%E3%83%83%E3%83%97%E6%96%B9%E5%BC%8F.md)

ユーザーに何らかの影響がありそうな修正ではないので、リリースノートへの記載は不要だと判断しました。